### PR TITLE
New gas fee escalation mechanism and other improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,12 +59,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
 name = "anyhow"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,11 +448,10 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.26"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+checksum = "95ed24df0632f708f5f6d8082675bef2596f7084dee3dd55f632290bf35bfe0f"
 dependencies = [
- "android-tzdata",
  "num-traits",
 ]
 
@@ -2751,7 +2744,7 @@ dependencies = [
  "mach",
  "once_cell",
  "raw-cpuid",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
 ]
@@ -4325,9 +4318,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/README.md
+++ b/README.md
@@ -62,6 +62,42 @@ running smoothly.
 An additional env variable `LOG_LEVEL` can be set to regulate which logs will be
 shown. Its value can be one of `trace`, `debug`, `info`, `warn` or `error`.
 
+## Testing with a local template playground
+
+In most cases this program will be tested with a local Carrot template
+playground. A few tips can be given for a good developer experience in this
+case. In particular:
+
+- Remember to start the playground before starting the answerer, as the answerer
+  needs a local RPC URL, and the playground bootstraps a local node as part of
+  its starting procedure.
+- Remember to update your local file with the correct local RPC URL depending on
+  the forked network on which the template is being set on.
+- In cases where a lot of past blocks must be indexed from the local RPC, the
+  local node's performance will be inevitably degraded, in some occasions even
+  rendering it unusable in the playground when simulating transactions. In this
+  case find out the current block number that the local node is pointing at
+  (also printed in the program's startup logs) and set it in the `checkpoints`
+  table in the database so that the program will detect the forked network to be
+  completely synced. Having a forked chain with id `CHAIN_ID`, a block number
+  `BLOCK_NUMBER` and the default connection string
+  `postgresql://user:password@127.0.0.1:5432/defillama-answerer` you can easily
+  update the checkpoint in the database by running
+  `psql postgresql://user:password@127.0.0.1:5432/defillama-answerer` in your
+  terminal followed by a
+  `INSERT INTO checkpoints (chain_id, block_number) VALUES (<CHAIN_ID>, <BLOCK_NUMBER>) ON CONFLICT (chain_id) DO UPDATE SET block_number = <BLOCK_NUMBER>;`
+  (remember the ending semicolon) in the Postgres prompt.
+- Local nodes such as Ganache work by default in "automining" mode, meaning that
+  no new block is produced unless a transaction is processed or unless manually
+  triggered. This is a problem because the answerer reacts on new block events
+  in order to process active oracles, so it might seem in certain cases that the
+  answerer has stopped processing events while in reality it's just waiting for
+  a new block to come. Luckily, most local nodes (such as Ganache and Anvil)
+  support the `evm_mine` RPC method, so in order to trigger a new block on a
+  local node running on a certain port `PORT` you can simply execute
+  `curl -X POST --data '{ "method": "evm_mine", "params": [] }' http:localhost:<PORT>`
+  in your terminal.
+
 ## Building a release binary
 
 Building a release (i.e. optimized) binary is simple, just run:

--- a/abis/DefiLlamaOracle.json
+++ b/abis/DefiLlamaOracle.json
@@ -5,6 +5,11 @@
                 "internalType": "address",
                 "name": "_answerer",
                 "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "_minimumElapsedTime",
+                "type": "uint256"
             }
         ],
         "stateMutability": "nonpayable",
@@ -18,6 +23,16 @@
     {
         "inputs": [],
         "name": "InvalidSpecification",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "MeasurementTimestampAfterKPITokenExpiration",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "MeasurementTimestampTooClose",
         "type": "error"
     },
     {
@@ -175,6 +190,32 @@
                 "internalType": "address",
                 "name": "",
                 "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "measurementTimestamp",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "minimumElapsedTime",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
             }
         ],
         "stateMutability": "view",

--- a/migrations/2023-08-24-074840_create_active_oracles_table/up.sql
+++ b/migrations/2023-08-24-074840_create_active_oracles_table/up.sql
@@ -1,9 +1,11 @@
 CREATE TABLE active_oracles (
-    address BYTEA PRIMARY KEY,
+    address BYTEA NOT NULL,
     chain_id INTEGER NOT NULL,
+    measurement_timestamp TIMESTAMP(0) NOT NULL,
     specification JSONB NOT NULL,
     answer_tx_hash BYTEA,
 
+    PRIMARY KEY(address, chain_id),
     CONSTRAINT address_length CHECK (LENGTH(address) = 20),
     CONSTRAINT answer_tx_hash_length CHECK (LENGTH(answer_tx_hash) = 32)
 );

--- a/migrations/2023-08-24-074840_create_active_oracles_table/up.sql
+++ b/migrations/2023-08-24-074840_create_active_oracles_table/up.sql
@@ -1,5 +1,9 @@
 CREATE TABLE active_oracles (
-    address CHAR(42) PRIMARY KEY,
+    address BYTEA PRIMARY KEY,
     chain_id INTEGER NOT NULL,
-    specification JSONB NOT NULL
+    specification JSONB NOT NULL,
+    answer_tx_hash BYTEA,
+
+    CONSTRAINT address_length CHECK (LENGTH(address) = 20),
+    CONSTRAINT answer_tx_hash_length CHECK (LENGTH(answer_tx_hash) = 32)
 );

--- a/src/commons.rs
+++ b/src/commons.rs
@@ -1,10 +1,4 @@
-use std::{
-    collections::HashMap,
-    net::Ipv4Addr,
-    path::Path,
-    sync::Arc,
-    time::{SystemTime, UNIX_EPOCH},
-};
+use std::{collections::HashMap, net::Ipv4Addr, path::Path, sync::Arc};
 
 use anyhow::Context;
 use diesel::{
@@ -14,7 +8,7 @@ use diesel::{
 use ethers::types::Address;
 use serde::{Deserialize, Serialize};
 
-use crate::{http_client::HttpClient, defillama::DefiLlamaClient};
+use crate::{defillama::DefiLlamaClient, http_client::HttpClient};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ContractConfig {
@@ -82,11 +76,4 @@ pub fn get_config(alt_path: Option<String>) -> anyhow::Result<Config> {
 
     tracing::info!("using path {} to read config", path);
     confy::load_path::<Config>(path).context("could not read config")
-}
-
-pub fn get_unix_timestamp() -> anyhow::Result<u64> {
-    Ok(SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .context("could not get unix timestamp")?
-        .as_secs())
 }

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -2,10 +2,10 @@
 
 diesel::table! {
     active_oracles (address) {
-        #[max_length = 42]
-        address -> Bpchar,
+        address -> Bytea,
         chain_id -> Int4,
         specification -> Jsonb,
+        answer_tx_hash -> Nullable<Bytea>,
     }
 }
 

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -1,9 +1,10 @@
 // @generated automatically by Diesel CLI.
 
 diesel::table! {
-    active_oracles (address) {
+    active_oracles (address, chain_id) {
         address -> Bytea,
         chain_id -> Int4,
+        measurement_timestamp -> Timestamp,
         specification -> Jsonb,
         answer_tx_hash -> Nullable<Bytea>,
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() {
     defillama_answerer::main().await
 }

--- a/src/scanner/commons.rs
+++ b/src/scanner/commons.rs
@@ -1,4 +1,7 @@
-use std::sync::Arc;
+use std::{
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
 use anyhow::Context;
 use diesel::{
@@ -6,7 +9,7 @@ use diesel::{
     r2d2::{ConnectionManager, Pool},
 };
 use ethers::{
-    abi::{AbiEncode, RawLog},
+    abi::RawLog,
     contract::{EthLogDecode, Multicall},
     types::{Address, Log},
 };
@@ -29,6 +32,7 @@ use crate::{
 
 pub struct DefiLlamaOracleData {
     address: Address,
+    measurement_timestamp: SystemTime,
     specification_cid: String,
 }
 
@@ -90,16 +94,16 @@ pub async fn parse_kpi_token_creation_log(
             Ok((finalized, template)) => {
                 if finalized {
                     tracing::info!(
-                        "oracle with address {} already finalized, skipping",
-                        oracle_address.encode_hex()
+                        "oracle with address 0x{:x} already finalized, skipping",
+                        oracle_address
                     );
                     continue;
                 }
 
                 if template.id.as_u64() != oracle_template_id {
                     tracing::info!(
-                        "oracle with address {} doesn't have the right template id, skipping",
-                        oracle_address.encode_hex()
+                        "oracle with address 0x{:x} doesn't have the right template id, skipping",
+                        oracle_address
                     );
                     continue;
                 }
@@ -116,8 +120,23 @@ pub async fn parse_kpi_token_creation_log(
                     }
                 };
 
+                let measurement_timestamp = match oracle.measurement_timestamp().await {
+                    Ok(measurement_timestamp) => measurement_timestamp,
+                    Err(error) => {
+                        tracing::error!(
+                            "could not fetch measurement timestamp for oracle at address {}, skipping - {:#}",
+                            oracle_address,
+                            error
+                        );
+                        continue;
+                    }
+                };
+                let measurement_timestamp =
+                    UNIX_EPOCH + Duration::from_secs(measurement_timestamp.as_u64());
+
                 data.push(DefiLlamaOracleData {
                     address: oracle_address,
+                    measurement_timestamp,
                     specification_cid: specification,
                 });
             }
@@ -143,12 +162,11 @@ pub async fn acknowledge_active_oracles(
 ) {
     let mut join_set = JoinSet::new();
     for data in oracles_data.into_iter() {
-        let oracle_address = data.address.encode_hex();
+        let oracle_address = format!("0x{}", data.address.to_string());
         join_set.spawn(
             acknowledge_active_oracle(
                 chain_id,
-                data.address,
-                data.specification_cid,
+                data,
                 db_connection_pool.clone(),
                 ipfs_http_client.clone(),
                 defillama_client.clone(),
@@ -177,17 +195,21 @@ pub async fn acknowledge_active_oracles(
 
 pub async fn acknowledge_active_oracle(
     chain_id: u64,
-    oracle_address: Address,
-    specification_cid: String,
+    oracle_data: DefiLlamaOracleData,
     db_connection_pool: Pool<ConnectionManager<PgConnection>>,
     ipfs_http_client: Arc<HttpClient>,
     defillama_client: Arc<DefiLlamaClient>,
     web3_storage_http_client: Option<Arc<HttpClient>>,
 ) -> anyhow::Result<()> {
-    match ipfs::fetch_specification_with_retry(ipfs_http_client.clone(), &specification_cid).await {
+    match ipfs::fetch_specification_with_retry(
+        ipfs_http_client.clone(),
+        &oracle_data.specification_cid,
+    )
+    .await
+    {
         Ok(specification) => {
             if !specification::validate(&specification, defillama_client).await {
-                tracing::error!("specification validation failed for oracle at address {}, this won't be handled", oracle_address);
+                tracing::error!("specification validation failed for oracle at address {:x}, this won't be handled", oracle_data.address);
                 return Ok(());
             }
 
@@ -197,8 +219,9 @@ pub async fn acknowledge_active_oracle(
 
             models::ActiveOracle::create(
                 database_connection,
-                oracle_address,
+                oracle_data.address,
                 chain_id,
+                oracle_data.measurement_timestamp,
                 specification,
             )
             .context("could not insert new active oracle into database")?;
@@ -207,10 +230,15 @@ pub async fn acknowledge_active_oracle(
                 ipfs::pin_cid_web3_storage_with_retry(
                     ipfs_http_client,
                     web3_storage_http_client,
-                    &specification_cid,
+                    &oracle_data.specification_cid,
                 )
                 .await?;
             }
+
+            tracing::info!(
+                "oracle with address 0x{:x} saved to database",
+                oracle_data.address
+            );
 
             Ok(())
         }

--- a/src/scanner/past.rs
+++ b/src/scanner/past.rs
@@ -101,15 +101,18 @@ pub async fn scan<'a>(
         )
         .await;
 
-        tracing::info!(
-            "{} -> {} - {} oracle creations detected - scanned {}% of past blocks",
-            from_block,
-            to_block,
-            oracles_data.len(),
-            ((to_block as f32 - context.factory_config.deployment_block as f32)
-                / full_range as f32)
-                * 100f32
-        );
+        let oracles_data_len = oracles_data.len();
+        if oracles_data_len > 0 {
+            tracing::info!(
+                "{} -> {} - {} oracle creations detected - scanned {}% of past blocks",
+                from_block,
+                to_block,
+                oracles_data_len,
+                ((to_block as f32 - context.factory_config.deployment_block as f32)
+                    / full_range as f32)
+                    * 100f32
+            );
+        }
 
         acknowledge_active_oracles(
             context.chain_id,

--- a/src/scanner/past.rs
+++ b/src/scanner/past.rs
@@ -56,9 +56,10 @@ pub async fn scan<'a>(
     let chunk_size = context.logs_blocks_range.unwrap_or(DEFAULT_LOGS_CHUNK_SIZE);
 
     tracing::info!(
-        "scanning {} past blocks, analyzing {} blocks at a time",
+        "scanning {} past blocks {} blocks at a time, starting from {}",
         block_number - from_block,
-        chunk_size
+        chunk_size,
+        block_number
     );
 
     // limit requests to infura to fetch past logs to a maximum of 2 per second

--- a/src/scanner/present.rs
+++ b/src/scanner/present.rs
@@ -104,7 +104,7 @@ async fn message_receiver(
             }
         }
         Err(error) => {
-            tracing::error!("error while receiving control over snapshot block number update from past indexer - {:#}", error);
+            tracing::error!("error while receiving control over snapshot block number update from past indexer\n\n{:#}", error);
         }
     }
 }

--- a/src/scanner/present.rs
+++ b/src/scanner/present.rs
@@ -265,7 +265,7 @@ async fn answer_active_oracle(
             Ok(db_connection) => db_connection,
             Err(error) => {
                 tracing::error!(
-                    "could not get database connection while trying to delete oracle from database - {}",
+                    "could not get database connection while trying to update oracle's answer tx hash\n\n{:#}",
                     error
                 );
                 return Ok(());

--- a/src/scanner/present.rs
+++ b/src/scanner/present.rs
@@ -6,6 +6,7 @@ use diesel::{
     PgConnection,
 };
 use ethers::{
+    abi::AbiEncode,
     contract::EthEvent,
     providers::{Middleware, StreamExt},
     types::{Block, Filter, H256},
@@ -15,7 +16,7 @@ use tokio::{
     sync::{oneshot, Mutex},
     task::JoinSet,
 };
-use tracing::error_span;
+use tracing::info_span;
 use tracing_futures::Instrument;
 
 use crate::{
@@ -34,10 +35,10 @@ pub async fn scan(
 ) -> anyhow::Result<()> {
     let update_snapshot_block_number = Arc::new(Mutex::new(false));
 
-    tokio::spawn(message_receiver(
-        receiver,
-        update_snapshot_block_number.clone(),
-    ));
+    tokio::spawn(
+        message_receiver(receiver, update_snapshot_block_number.clone())
+            .instrument(info_span!("message-receiver")),
+    );
 
     loop {
         let signer = get_signer(
@@ -191,6 +192,7 @@ async fn handle_active_oracles_answering(
     let mut join_set: JoinSet<Result<(), anyhow::Error>> = JoinSet::new();
     for active_oracle in active_oracles.into_iter() {
         let chain_id = context.chain_id;
+        let oracle_address = active_oracle.address.encode_hex();
         join_set.spawn(
             answer_active_oracle(
                 signer.clone(),
@@ -198,13 +200,21 @@ async fn handle_active_oracles_answering(
                 context.defillama_client.clone(),
                 active_oracle,
             )
-            .instrument(error_span!("answer", chain_id)),
+            .instrument(info_span!("answer", chain_id, oracle_address)),
         );
     }
 
-    // wait forever unless some task stops with an error
-    while let Some(res) = join_set.join_next().await {
-        let _ = res.context("task unexpectedly stopped")?;
+    while let Some(join_result) = join_set.join_next().await {
+        match join_result {
+            Ok(result) => {
+                if let Err(error) = result {
+                    tracing::error!("a task unexpectedly stopped with an error:\n\n{:#}", error);
+                }
+            }
+            Err(error) => {
+                tracing::error!("an error happened while joining a task:\n\n{:#}", error);
+            }
+        }
     }
 
     Ok(())
@@ -214,16 +224,24 @@ async fn answer_active_oracle(
     signer: Arc<Signer>,
     db_connection_pool: Pool<ConnectionManager<PgConnection>>,
     defillama_client: Arc<DefiLlamaClient>,
-    active_oracle: models::ActiveOracle,
+    mut active_oracle: models::ActiveOracle,
 ) -> anyhow::Result<()> {
+    if let Some(tx_hash) = active_oracle.answer_tx_hash {
+        tracing::info!(
+            "answering procedure already active for oracle with tx hash {}, skipping",
+            tx_hash.0.encode_hex()
+        );
+        return Ok(());
+    }
+
     if let Some(answer) =
         specification::answer(&active_oracle.specification, defillama_client).await
     {
-        // if we come here, an answer is available and we should submit it
+        // if we arrive here, an answer is available and we should submit it
 
         tracing::info!(
-            "answering active oracle 0x{:X} with value {}",
-            active_oracle.address.deref(),
+            "answering active oracle {} with value {}",
+            active_oracle.address.encode_hex(),
             answer
         );
         let oracle = DefiLlamaOracle::new(active_oracle.address.0, signer);
@@ -240,7 +258,25 @@ async fn answer_active_oracle(
             }
         };
 
-        let receipt: Option<ethers::types::TransactionReceipt> = match tx.await {
+        let mut db_connection = match db_connection_pool
+            .get()
+            .context("could not get new connection from pool")
+        {
+            Ok(db_connection) => db_connection,
+            Err(error) => {
+                tracing::error!(
+                    "could not get database connection while trying to delete oracle from database - {}",
+                    error
+                );
+                return Ok(());
+            }
+        };
+        if let Err(error) = active_oracle.update_answer_tx_hash(&mut db_connection, tx.tx_hash()) {
+            tracing::error!("{:#}", error);
+            return Ok(());
+        }
+
+        let receipt = match tx.await {
             Ok(receipt) => receipt,
             Err(error) => {
                 tracing::error!(
@@ -248,6 +284,13 @@ async fn answer_active_oracle(
                     active_oracle.address.deref(),
                     error,
                 );
+
+                // we need to throw this error as this needs to be addressed immediately.
+                // not being able to delete the tx hash for an oracle once an answer task
+                // errors out might cause a deadlock preventing any answering task from
+                // starting in the future
+                active_oracle.delete_answer_tx_hash(&mut db_connection)?;
+
                 return Ok(());
             }
         };
@@ -278,28 +321,15 @@ async fn answer_active_oracle(
             );
         }
 
-        let mut db_connection = match db_connection_pool
-            .get()
-            .context("could not get new connection from pool")
-        {
-            Ok(db_connection) => db_connection,
-            Err(error) => {
-                tracing::error!(
-                    "could not get database connection while trying to delete oracle from database - {}",
-                    error
-                );
-                return Ok(());
-            }
-        };
-
+        let active_oracle_address = active_oracle.address.0.clone();
         if let Err(error) = active_oracle.delete(&mut db_connection) {
             tracing::error!("could not delete oracle from database - {}", error);
             return Ok(());
         }
 
         tracing::info!(
-            "oracle 0x{:X} successfully finalized with value {}",
-            active_oracle.address.deref(),
+            "oracle {} successfully finalized with value {}",
+            active_oracle_address.encode_hex(),
             answer
         );
     }

--- a/src/signer.rs
+++ b/src/signer.rs
@@ -2,15 +2,12 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, Context};
 use ethers::{
-    middleware::{
-        gas_escalator::{Frequency, GasEscalatorMiddleware, GeometricGasPrice},
-        SignerMiddleware,
-    },
+    middleware::SignerMiddleware,
     providers::{Middleware, Provider, Ws},
     signers::{LocalWallet, Signer as EthersSigner},
 };
 
-pub type Signer = GasEscalatorMiddleware<SignerMiddleware<Provider<Ws>, LocalWallet>>;
+pub type Signer = SignerMiddleware<Provider<Ws>, LocalWallet>;
 
 pub async fn get_signer(
     url: Arc<String>,
@@ -34,15 +31,9 @@ pub async fn get_signer(
     if chain_id_from_provider.as_u64() != expected_chain_id {
         Err(anyhow!("chain id mismatch, provider gave {chain_id_from_provider} while {expected_chain_id} was expected"))
     } else {
-        // increase gas price 30% every 10 seconds
-        // FIXME: maybe find a way to enforce a maximum price
-        let escalator = GeometricGasPrice::new(1.3, 10u64, None::<u64>);
-        let signer = GasEscalatorMiddleware::new(
-            SignerMiddleware::new(provider, answerer_wallet.with_chain_id(expected_chain_id)),
-            escalator,
-            Frequency::PerBlock,
-        );
-
-        Ok(Arc::new(signer))
+        Ok(Arc::new(SignerMiddleware::new(
+            provider,
+            answerer_wallet.with_chain_id(expected_chain_id),
+        )))
     }
 }

--- a/src/signer.rs
+++ b/src/signer.rs
@@ -2,12 +2,15 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, Context};
 use ethers::{
-    middleware::SignerMiddleware,
+    middleware::{
+        gas_escalator::{Frequency, GasEscalatorMiddleware, GeometricGasPrice},
+        SignerMiddleware,
+    },
     providers::{Middleware, Provider, Ws},
     signers::{LocalWallet, Signer as EthersSigner},
 };
 
-pub type Signer = SignerMiddleware<Provider<Ws>, LocalWallet>;
+pub type Signer = GasEscalatorMiddleware<SignerMiddleware<Provider<Ws>, LocalWallet>>;
 
 pub async fn get_signer(
     url: Arc<String>,
@@ -31,9 +34,15 @@ pub async fn get_signer(
     if chain_id_from_provider.as_u64() != expected_chain_id {
         Err(anyhow!("chain id mismatch, provider gave {chain_id_from_provider} while {expected_chain_id} was expected"))
     } else {
-        Ok(Arc::new(SignerMiddleware::new(
-            provider,
-            answerer_wallet.with_chain_id(expected_chain_id),
-        )))
+        // increase gas price 30% every 10 seconds
+        // FIXME: maybe find a way to enforce a maximum price
+        let escalator = GeometricGasPrice::new(1.3, 10u64, None::<u64>);
+        let signer = GasEscalatorMiddleware::new(
+            SignerMiddleware::new(provider, answerer_wallet.with_chain_id(expected_chain_id)),
+            escalator,
+            Frequency::PerBlock,
+        );
+
+        Ok(Arc::new(signer))
     }
 }

--- a/src/specification.rs
+++ b/src/specification.rs
@@ -35,7 +35,7 @@ pub trait Answer<'a, P: Serialize + Deserialize<'a> + Debug + PartialEq> {
 
 macro_rules! impl_spec_validation_and_handling {
     ($($spec_variant: ident => $handler: ident),*) => {
-    pub async fn validate<'a>(specification: &Specification, defillama_client: Arc<DefiLlamaClient>) -> bool {
+        pub async fn validate<'a>(specification: &Specification, defillama_client: Arc<DefiLlamaClient>) -> bool {
             let result = match specification {
                 $(Specification::$spec_variant(payload) => $handler::validate(&payload, defillama_client),)*
             }.await;
@@ -79,12 +79,11 @@ mod test {
     fn serialize_tvl() {
         let metric = Specification::Tvl(TvlPayload {
             protocol: "aave".to_owned(),
-            timestamp: 10,
         });
 
         assert_eq!(
             serde_json::to_string(&metric).unwrap(),
-            r#"{"metric":"tvl","payload":{"protocol":"aave","timestamp":10}}"#
+            r#"{"metric":"tvl","payload":{"protocol":"aave"}}"#
         );
     }
 
@@ -136,12 +135,11 @@ mod test {
         // valid json, valid metric, valid payload
         assert_eq!(
             serde_json::from_str::<Specification>(
-                r#"{"metric":"tvl","payload":{"protocol":"foo","timestamp":10}}"#,
+                r#"{"metric":"tvl","payload":{"protocol":"foo"}}"#,
             )
             .unwrap(),
             Specification::Tvl(TvlPayload {
                 protocol: "foo".to_owned(),
-                timestamp: 10
             })
         );
     }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -5,7 +5,9 @@ use tracing_subscriber::{EnvFilter, FmtSubscriber};
 pub fn init() -> anyhow::Result<()> {
     let subscriber = FmtSubscriber::builder()
         .json()
-        .with_span_list(false)
+        .with_span_list(true)
+        .with_current_span(false)
+        .with_target(false)
         .with_env_filter(
             EnvFilter::builder()
                 .with_env_var("LOG_LEVEL")

--- a/tests/active_oracle.rs
+++ b/tests/active_oracle.rs
@@ -5,10 +5,12 @@ use anyhow::Context;
 use defillama_answerer::{
     db::{
         models::{self, ActiveOracle},
+        schema::active_oracles,
         DbAddress, DbTxHash,
     },
     specification::{handlers::tvl::TvlPayload, Specification},
 };
+use diesel::prelude::*;
 use ethers::{abi::Address, types::H256};
 
 #[test]
@@ -96,4 +98,56 @@ fn test_answer_tx_hash_update() {
     let active_oracle_from_db = oracles.into_iter().nth(0).unwrap();
     assert_eq!(active_oracle_from_db, active_oracle);
     assert_eq!(active_oracle_from_db.answer_tx_hash, Some(DbTxHash(hash)));
+}
+
+#[test]
+fn test_answer_tx_hash_deletion() {
+    let context = TestContext::new("active_oracle_answer_tx_hash_deletion");
+
+    // save initial active oracle to db
+    let active_oracle = ActiveOracle {
+        address: DbAddress(Address::random()),
+        chain_id: 100,
+        specification: Specification::Tvl(TvlPayload {
+            protocol: "foo".to_owned(),
+            timestamp: 10,
+        }),
+        answer_tx_hash: Some(DbTxHash(H256::random())),
+    };
+    let mut db_connection = context
+        .db_connection_pool
+        .get()
+        .expect("could not get connection from pool");
+    diesel::insert_into(active_oracles::table)
+        .values(&active_oracle)
+        .execute(&mut db_connection)
+        .context("could not insert oracle into database")
+        .expect("could not save active oracle to database");
+
+    // get it back and check that it's the same as the one we actually wanted to save
+    let oracles = models::ActiveOracle::get_all_for_chain_id(
+        &mut db_connection,
+        active_oracle.chain_id as u64,
+    )
+    .expect("could not get active oracles from database");
+    assert_eq!(oracles.len(), 1);
+    let mut oracle_from_db = oracles.into_iter().nth(0).unwrap();
+    assert_eq!(oracle_from_db, active_oracle);
+
+    // remove its tx hash
+    oracle_from_db
+        .delete_answer_tx_hash(&mut db_connection)
+        .expect("could not delete answer tx hash");
+    assert!(oracle_from_db.answer_tx_hash.is_none());
+
+    // get it once again from the database and verify that the tx hash is not there anymore
+    let oracles = models::ActiveOracle::get_all_for_chain_id(
+        &mut db_connection,
+        active_oracle.chain_id as u64,
+    )
+    .expect("could not get active oracles from database");
+    assert_eq!(oracles.len(), 1);
+    let updated_oracle_from_db = oracles.into_iter().nth(0).unwrap();
+    assert_eq!(updated_oracle_from_db, oracle_from_db);
+    assert!(updated_oracle_from_db.answer_tx_hash.is_none());
 }

--- a/tests/active_oracle.rs
+++ b/tests/active_oracle.rs
@@ -1,0 +1,99 @@
+mod commons;
+
+use crate::commons::context::TestContext;
+use anyhow::Context;
+use defillama_answerer::{
+    db::{
+        models::{self, ActiveOracle},
+        DbAddress, DbTxHash,
+    },
+    specification::{handlers::tvl::TvlPayload, Specification},
+};
+use ethers::{abi::Address, types::H256};
+
+#[test]
+fn test_to_from_sql() {
+    let context = TestContext::new("active_oracle_to_from_sql");
+
+    let active_oracle = ActiveOracle {
+        address: DbAddress(Address::random()),
+        chain_id: 100,
+        specification: Specification::Tvl(TvlPayload {
+            protocol: "foo".to_owned(),
+            timestamp: 10,
+        }),
+        answer_tx_hash: None,
+    };
+
+    let mut db_connection = context
+        .db_connection_pool
+        .get()
+        .expect("could not get connection from pool");
+    models::ActiveOracle::create(
+        &mut db_connection,
+        active_oracle.address.0,
+        active_oracle.chain_id as u64,
+        active_oracle.specification.clone(),
+    )
+    .expect("could not save active oracle to database");
+
+    let oracles = models::ActiveOracle::get_all_for_chain_id(
+        &mut db_connection,
+        active_oracle.chain_id as u64,
+    )
+    .expect("could not get active oracles from database");
+    assert_eq!(oracles.len(), 1);
+    assert_eq!(oracles.into_iter().nth(0).unwrap(), active_oracle);
+}
+
+#[test]
+fn test_answer_tx_hash_update() {
+    let context = TestContext::new("active_oracle_answer_tx_hash_update");
+
+    let mut active_oracle = ActiveOracle {
+        address: DbAddress(Address::random()),
+        chain_id: 100,
+        specification: Specification::Tvl(TvlPayload {
+            protocol: "foo".to_owned(),
+            timestamp: 10,
+        }),
+        answer_tx_hash: None,
+    };
+
+    let mut db_connection = context
+        .db_connection_pool
+        .get()
+        .expect("could not get connection from pool");
+    models::ActiveOracle::create(
+        &mut db_connection,
+        active_oracle.address.0,
+        active_oracle.chain_id as u64,
+        active_oracle.specification.clone(),
+    )
+    .expect("could not save active oracle to database");
+
+    let oracles = models::ActiveOracle::get_all_for_chain_id(
+        &mut db_connection,
+        active_oracle.chain_id as u64,
+    )
+    .expect("could not get active oracles from database");
+    assert_eq!(oracles.len(), 1);
+    assert_eq!(oracles.into_iter().nth(0).unwrap(), active_oracle);
+
+    let hash = H256::random();
+    active_oracle
+        .update_answer_tx_hash(&mut db_connection, hash)
+        .context("could not update answer tx hash")
+        .unwrap();
+
+    let oracles = models::ActiveOracle::get_all_for_chain_id(
+        &mut db_connection,
+        active_oracle.chain_id as u64,
+    )
+    .expect("could not get active oracles from database");
+    assert_eq!(oracles.len(), 1);
+
+    let active_oracle_from_db = oracles.into_iter().nth(0).unwrap();
+    assert_eq!(active_oracle_from_db, active_oracle);
+    assert_eq!(active_oracle_from_db.answer_tx_hash, Some(DbTxHash(hash)));
+}

--- a/tests/specification.rs
+++ b/tests/specification.rs
@@ -1,5 +1,7 @@
 mod commons;
 
+use std::time::UNIX_EPOCH;
+
 use crate::commons::context::TestContext;
 use defillama_answerer::{
     db::models,
@@ -14,7 +16,6 @@ fn test_to_from_sql() {
     let chain_id = 100;
     let specification = Specification::Tvl(TvlPayload {
         protocol: "foo".to_owned(),
-        timestamp: 10,
     });
 
     let mut db_connection = context
@@ -25,12 +26,14 @@ fn test_to_from_sql() {
         &mut db_connection,
         Address::random(),
         chain_id,
+        UNIX_EPOCH,
         specification.clone(),
     )
     .expect("could not save active oracle to database");
 
-    let oracles = models::ActiveOracle::get_all_for_chain_id(&mut db_connection, chain_id)
-        .expect("could not get active oracles from database");
+    let oracles =
+        models::ActiveOracle::get_all_answerable_for_chain_id(&mut db_connection, chain_id)
+            .expect("could not get active oracles from database");
     assert_eq!(oracles.len(), 1);
     assert_eq!(
         oracles.into_iter().nth(0).unwrap().specification,


### PR DESCRIPTION
In particular:

- Add `bytea` `answer_tx_hash` column to `active_oracles` table
- Convert address column to `bytea` instead of text to save storage
- Add constraints on the length of both `address` and `answer_tx_hash` columns on the `active_oracles` table
- Avoid showing target in logs (noise) and show the full tree of spans instead of just the current one
- Improve log messages across the board
- Improve task error/join error handling in join sets
- Introduce a gas escalation mechanism to make sure the answer oracle transaction is processed in a timely manner
- While answering an oracle, return early if a previous answering task is still running for it (check if `answer_tx_hash` is there)
- While no answering task is there, start it by submitting a tx and update the answer tx hash to reflect it on the database
- If the answering tx errors out, delete the answer tx hash so that a new answering task can start
- Add tests
- Avoid returning a result from the entrypoint, opt for direct logging of errors + exit(1) so that fatal error logs also have the correct json structure