### PR TITLE
feat: extend rate limiting support and implement web3.storage backups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2986,7 +2986,6 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
- "mime_guess",
  "native-tls",
  "once_cell",
  "percent-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,7 @@ diesel = { version = "2.1.0", features = ["postgres", "r2d2", "serde_json"] }
 diesel_migrations = { version = "2.1.0", features = ["postgres"] }
 ethers = { version = "2.0.7", features = ["ws", "rustls"] }
 governor = "0.5.1"
-reqwest = { version = "0.11.18", features = [
-    "serde_json",
-    "multipart",
-    "stream",
-] }
+reqwest = { version = "0.11.18", features = ["serde_json", "stream"] }
 rust_decimal = "1.32.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.91"

--- a/src/api.rs
+++ b/src/api.rs
@@ -5,14 +5,14 @@ use std::{net::Ipv4Addr, sync::Arc};
 
 use warp::Filter;
 
-use crate::{defillama::DefiLlamaClient, specification};
+use crate::http_client::HttpClient;
 
 pub async fn serve(
     host: Ipv4Addr,
     port: u16,
-    defillama_client: Arc<DefiLlamaClient>,
+    defillama_http_client: Arc<HttpClient>,
 ) -> anyhow::Result<()> {
-    warp::serve(documentation::handlers().or(specifications::handlers(defillama_client)))
+    warp::serve(documentation::handlers().or(specifications::handlers(defillama_http_client)))
         .run((host, port))
         .await;
 

--- a/src/api/documentation.rs
+++ b/src/api/documentation.rs
@@ -9,7 +9,7 @@ use warp::{
     redirect, Filter, Rejection, Reply,
 };
 
-use super::{specification, specifications};
+use super::{super::specification, specifications};
 
 #[derive(OpenApi)]
 #[openapi(

--- a/src/commons.rs
+++ b/src/commons.rs
@@ -8,7 +8,7 @@ use diesel::{
 use ethers::types::Address;
 use serde::{Deserialize, Serialize};
 
-use crate::{defillama::DefiLlamaClient, http_client::HttpClient};
+use crate::http_client::HttpClient;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ContractConfig {
@@ -56,7 +56,7 @@ pub struct ChainExecutionContext {
     pub template_id: u64,
     pub answerer_private_key: Arc<String>,
     pub ipfs_http_client: Arc<HttpClient>,
-    pub defillama_client: Arc<DefiLlamaClient>,
+    pub defillama_http_client: Arc<HttpClient>,
     pub web3_storage_http_client: Option<Arc<HttpClient>>,
     pub db_connection_pool: Pool<ConnectionManager<PgConnection>>,
     pub factory_config: ContractConfig,

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -1,16 +1,59 @@
 use std::time::Duration;
 
 use anyhow::Context;
+use governor::{
+    clock::{QuantaClock, QuantaInstant},
+    middleware::NoOpMiddleware,
+    state::{InMemoryState, NotKeyed},
+    RateLimiter,
+};
 
 const HTTP_REQUEST_TIMEOUT: u64 = 30_000;
 
 pub struct HttpClient {
     inner: reqwest::Client,
-    base: reqwest::Url,
+    base_url: reqwest::Url,
     bearer_auth_token: Option<String>,
+    rate_limiter:
+        Option<RateLimiter<NotKeyed, InMemoryState, QuantaClock, NoOpMiddleware<QuantaInstant>>>,
 }
 
 impl HttpClient {
+    pub fn builder() -> HttpClientBuilder {
+        HttpClientBuilder::new()
+    }
+
+    pub async fn request<S: Into<String>>(
+        &self,
+        method: reqwest::Method,
+        path: S,
+    ) -> anyhow::Result<reqwest::RequestBuilder> {
+        let path_owned = path.into();
+        let url = self.base_url.join(path_owned.as_ref()).context(format!(
+            "could not join {} and {} in an url",
+            self.base_url, path_owned,
+        ))?;
+
+        if let Some(rate_limiter) = &self.rate_limiter {
+            rate_limiter.until_ready().await;
+        }
+
+        let builder = self.inner.request(method, url);
+        Ok(match &self.bearer_auth_token {
+            Some(token) => builder.bearer_auth(token),
+            None => builder,
+        })
+    }
+}
+
+pub struct HttpClientBuilder {
+    base_url: String,
+    bearer_auth_token: Option<String>,
+    rate_limiter:
+        Option<RateLimiter<NotKeyed, InMemoryState, QuantaClock, NoOpMiddleware<QuantaInstant>>>,
+}
+
+impl HttpClientBuilder {
     fn base_client() -> reqwest::Client {
         reqwest::Client::builder()
             .timeout(Duration::from_secs(HTTP_REQUEST_TIMEOUT))
@@ -18,37 +61,44 @@ impl HttpClient {
             .unwrap() // panic on error
     }
 
-    pub fn new(base: reqwest::Url) -> Self {
+    pub fn new() -> Self {
         Self {
-            inner: Self::base_client(),
-            base,
+            base_url: "".to_owned(),
             bearer_auth_token: None,
+            rate_limiter: None,
         }
     }
 
-    pub fn new_with_bearer_auth(base: reqwest::Url, token: String) -> Self {
-        Self {
+    pub fn build(self) -> anyhow::Result<HttpClient> {
+        Ok(HttpClient {
             inner: Self::base_client(),
-            base: base,
-            bearer_auth_token: Some(token),
-        }
+            base_url: reqwest::Url::parse(self.base_url.as_str())
+                .context(format!("could not parse url {}", self.base_url))?,
+            bearer_auth_token: self.bearer_auth_token,
+            rate_limiter: self.rate_limiter,
+        })
     }
 
-    pub fn request<S: Into<String>>(
-        &self,
-        method: reqwest::Method,
-        path: S,
-    ) -> anyhow::Result<reqwest::RequestBuilder> {
-        let path_owned = path.into();
-        let url = self.base.join(path_owned.as_ref()).context(format!(
-            "could not join {} and {} in an url",
-            self.base, path_owned,
-        ))?;
+    pub fn base_url(mut self, base_url: String) -> Self {
+        self.base_url = base_url;
+        self
+    }
+    
+    pub fn bearer_auth_token(mut self, token: String) -> Self {
+        self.bearer_auth_token = Some(token);
+        self
+    }
 
-        let builder = self.inner.request(method, url);
-        Ok(match &self.bearer_auth_token {
-            Some(token) => builder.bearer_auth(token),
-            None => builder,
-        })
+    pub fn rate_limiter(
+        mut self,
+        rate_limiter: RateLimiter<
+            NotKeyed,
+            InMemoryState,
+            QuantaClock,
+            NoOpMiddleware<QuantaInstant>,
+        >,
+    ) -> Self {
+        self.rate_limiter = Some(rate_limiter);
+        self
     }
 }

--- a/src/ipfs.rs
+++ b/src/ipfs.rs
@@ -1,15 +1,11 @@
 use std::{sync::Arc, time::Duration};
 
-use anyhow::Context;
+use anyhow::{anyhow, Context};
 use backoff::{future::retry, ExponentialBackoffBuilder};
-use reqwest::Method;
+use reqwest::{Body, Method};
+use serde::Deserialize;
 
 use crate::{http_client::HttpClient, specification::Specification};
-
-// #[derive(Deserialize)]
-// struct CARUploadResponse {
-//     cid: String,
-// }
 
 pub async fn fetch_specification_with_retry(
     ipfs_http_client: Arc<HttpClient>,
@@ -17,7 +13,8 @@ pub async fn fetch_specification_with_retry(
 ) -> anyhow::Result<Specification> {
     let fetch = || async {
         let response = match ipfs_http_client
-            .request(Method::POST, format!("/api/v0/cat?arg={cid}"))?
+            .request(Method::POST, format!("/api/v0/cat?arg={cid}"))
+            .await?
             .send()
             .await
             .context(format!("could not fetch cid {cid}"))
@@ -35,10 +32,10 @@ pub async fn fetch_specification_with_retry(
         match response.json::<Specification>().await.context(format!(
             "could not deserialize raw response to json spec for {cid}"
         )) {
-            Ok(spec) => Ok(spec),
+            Ok(specification) => Ok(specification),
             Err(err) => {
                 tracing::error!("{:#}", err);
-                // if we can't parse the json to a valid spec, we just
+                // if we can't parse the json to text, we just
                 // stop retrying
                 Err(backoff::Error::Permanent(err))
             }
@@ -58,101 +55,92 @@ pub async fn fetch_specification_with_retry(
     .context(format!("could not fetch cid {} from ipfs", cid))
 }
 
-pub async fn pin_cid_web3_storage_with_retry(
+#[derive(Deserialize)]
+struct CARUploadResponse {
+    cid: String,
+}
+
+pub async fn pin_on_web3_storage_with_retry(
     ipfs_http_client: Arc<HttpClient>,
     web3_storage_http_client: Arc<HttpClient>,
     cid: &String,
 ) -> anyhow::Result<()> {
-    // TODO: actually implement this. It coudl also be simplified by directly
-    // pinning the raw specification content instead of fetching the CAR etc,
-    // since we already have to fetch it anyway to process it
+    let pin = || async {
+        // export dag from ipfs
+        let car_response = match ipfs_http_client
+            .request(
+                Method::POST,
+                format!("/api/v0/dag/export?arg={cid}&progress=false"),
+            )
+            .await?
+            .send()
+            .await
+            .context(format!("could not get car for {cid}"))
+        {
+            Ok(res) => res,
+            Err(err) => {
+                tracing::error!("{}", err);
+                return Err(backoff::Error::Transient {
+                    err,
+                    retry_after: None,
+                });
+            }
+        };
 
-    // limit requests to web3.storage to a maximum of 2 per second
-    // let rate_limiter = RateLimiter::direct(Quota::per_second(NonZeroU32::new(2u32).unwrap()));
+        // upload car to web3.storage
+        let car_upload_response = match web3_storage_http_client
+            .request(Method::POST, "/car")
+            .await?
+            .body(Body::wrap_stream(car_response.bytes_stream()))
+            .send()
+            .await
+            .context(format!("could not pin {cid} to web3.storage"))
+        {
+            Ok(res) => res,
+            Err(err) => {
+                tracing::error!("{}", err);
+                return Err(backoff::Error::Transient {
+                    err,
+                    retry_after: None,
+                });
+            }
+        };
 
-    // let pin = || async {
-    //     // export dag from ipfs
-    //     let car_response = match ipfs_http_client
-    //         .request(
-    //             Method::GET,
-    //             format!("/api/v0/dag/export?arg={cid}&progress=false"),
-    //         )?
-    //         .send()
-    //         .await
-    //         .map_err(|e| anyhow!(e))
-    //         .context(format!("could not get car for {cid}"))
-    //     {
-    //         Ok(res) => res,
-    //         Err(err) => {
-    //             tracing::error!("{}", err);
-    //             return Err(backoff::Error::Transient {
-    //                 err,
-    //                 retry_after: None,
-    //             });
-    //         }
-    //     };
+        let car_upload_response = match car_upload_response
+            .json::<CARUploadResponse>()
+            .await
+            .context(format!(
+                "could not convert web3.storage response for {cid} to json"
+            )) {
+            Ok(res) => res,
+            Err(err) => {
+                tracing::error!("{}", err);
+                return Err(backoff::Error::Transient {
+                    err,
+                    retry_after: None,
+                });
+            }
+        };
 
-    //     // apply rate limiting
-    //     rate_limiter.until_ready().await;
+        if car_upload_response.cid != *cid {
+            return Err(backoff::Error::Permanent(anyhow!(
+                "cid mismatch between local pin and web3.storage: got {}, expected {}",
+                car_upload_response.cid,
+                cid
+            )));
+        }
 
-    //     // upload car to web3.storage
-    //     let car_upload_response = match web3_storage_http_client
-    //         .request(Method::POST, "/car")?
-    //         .body(Body::wrap_stream(car_response.bytes_stream()))
-    //         .send()
-    //         .await
-    //         .map_err(|e| anyhow!(e))
-    //         .context(format!("could not pin {cid} to web3.storage"))
-    //     {
-    //         Ok(res) => res,
-    //         Err(err) => {
-    //             tracing::error!("{}", err);
-    //             return Err(backoff::Error::Transient {
-    //                 err,
-    //                 retry_after: None,
-    //             });
-    //         }
-    //     };
+        tracing::info!("specification with cid {} backed up on web3.storage", cid);
 
-    //     let car_upload_response = match car_upload_response
-    //         .json::<CARUploadResponse>()
-    //         .await
-    //         .map_err(|e| anyhow!(e))
-    //         .context(format!(
-    //             "could not convert web3.storage response for {cid} to json"
-    //         )) {
-    //         Ok(res) => res,
-    //         Err(err) => {
-    //             tracing::error!("{}", err);
-    //             return Err(backoff::Error::Transient {
-    //                 err,
-    //                 retry_after: None,
-    //             });
-    //         }
-    //     };
+        Ok(())
+    };
 
-    //     // check if cids are matching
-    //     if &car_upload_response.cid != cid {
-    //         return Err(backoff::Error::Transient {
-    //             err: anyhow!("cid mismatch between local pin and web3.storage"),
-    //             retry_after: None,
-    //         });
-    //     }
-
-    //     Ok(())
-    // };
-
-    // match retry(
-    //     ExponentialBackoffBuilder::new()
-    //         .with_max_elapsed_time(Some(Duration::from_secs(86_400)))
-    //         .build(),
-    //     pin,
-    // )
-    // .await
-    // {
-    //     Ok(_) => tracing::info!("backed up {} on web3.storage", cid),
-    //     Err(error) => tracing::error!("could back up {} on web3.storage - {}", cid, error),
-    // }
-
-    Ok(())
+    retry(
+        ExponentialBackoffBuilder::new()
+            .with_max_elapsed_time(Some(Duration::from_secs(86_400)))
+            .build(),
+        pin,
+    )
+    .await
+    .context(format!("could not back up {} on web3.storage", cid))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ use diesel_migrations::{embed_migrations, EmbeddedMigrations, MigrationHarness};
 
 pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!("./migrations");
 
-const MAX_CALLS_PER_SECOND_DEFILLAMA: u32 = 10;
+const MAX_CALLS_PER_SECOND_DEFILLAMA: u32 = 7;
 const MAX_CALLS_PER_SECOND_WEB3_STORAGE: u32 = 3;
 
 pub async fn main() {

--- a/src/scanner/commons.rs
+++ b/src/scanner/commons.rs
@@ -26,7 +26,7 @@ use crate::{
     http_client::HttpClient,
     ipfs,
     signer::Signer,
-    specification::{self, Specification},
+    specification,
 };
 
 pub struct DefiLlamaOracleData {

--- a/src/scanner/past.rs
+++ b/src/scanner/past.rs
@@ -120,7 +120,7 @@ pub async fn scan<'a>(
             oracles_data,
             context.db_connection_pool.clone(),
             context.ipfs_http_client.clone(),
-            context.defillama_client.clone(),
+            context.defillama_http_client.clone(),
             context.web3_storage_http_client.clone(),
         )
         .await;

--- a/src/specification.rs
+++ b/src/specification.rs
@@ -8,7 +8,7 @@ use ethers::types::U256;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-use crate::{defillama::DefiLlamaClient, specification::handlers::tvl::TvlHandler};
+use crate::{http_client::HttpClient, specification::handlers::tvl::TvlHandler};
 
 use self::handlers::tvl::TvlPayload;
 
@@ -22,22 +22,22 @@ pub enum Specification {
 
 #[async_trait]
 pub trait Validate<'a, P: Serialize + Deserialize<'a> + Debug + PartialEq> {
-    async fn validate(payload: &P, defillama_client: Arc<DefiLlamaClient>) -> anyhow::Result<bool>;
+    async fn validate(payload: &P, defillama_http_client: Arc<HttpClient>) -> anyhow::Result<bool>;
 }
 
 #[async_trait]
 pub trait Answer<'a, P: Serialize + Deserialize<'a> + Debug + PartialEq> {
     async fn answer(
         payload: &P,
-        defillama_client: Arc<DefiLlamaClient>,
+        defillama_http_client: Arc<HttpClient>,
     ) -> anyhow::Result<Option<U256>>;
 }
 
 macro_rules! impl_spec_validation_and_handling {
     ($($spec_variant: ident => $handler: ident),*) => {
-        pub async fn validate<'a>(specification: &Specification, defillama_client: Arc<DefiLlamaClient>) -> bool {
+        pub async fn validate<'a>(specification: &Specification, defillama_http_client: Arc<HttpClient>) -> bool {
             let result = match specification {
-                $(Specification::$spec_variant(payload) => $handler::validate(&payload, defillama_client),)*
+                $(Specification::$spec_variant(payload) => $handler::validate(&payload, defillama_http_client),)*
             }.await;
             match result {
                 Ok(val) => val,
@@ -48,9 +48,9 @@ macro_rules! impl_spec_validation_and_handling {
             }
         }
 
-        pub async fn answer<'a>(specification: &Specification, defillama_client: Arc<DefiLlamaClient>) -> Option<U256> {
+        pub async fn answer<'a>(specification: &Specification, defillama_http_client: Arc<HttpClient>) -> Option<U256> {
             let result = match specification {
-                $(Specification::$spec_variant(payload) => $handler::answer(&payload, defillama_client),)*
+                $(Specification::$spec_variant(payload) => $handler::answer(&payload, defillama_http_client),)*
             }.await;
             match result {
                 Ok(val) => val,


### PR DESCRIPTION
- integrate new builder pattern in http client
- add the possibility to specify a rate limiter for calls in http client
- implement web3.storage backup of specifications
- remove defillama client
- move defillama tvl fetching logic inside tvl handler, leveraging the new rate limited defillama http client

Integrates and extends #5 