### PR TITLE
feat: save answer

### DIFF
--- a/migrations/2023-08-24-074840_create_active_oracles_table/up.sql
+++ b/migrations/2023-08-24-074840_create_active_oracles_table/up.sql
@@ -4,8 +4,12 @@ CREATE TABLE active_oracles (
     measurement_timestamp TIMESTAMP(0) NOT NULL,
     specification JSONB NOT NULL,
     answer_tx_hash BYTEA,
+    -- using raw bytes as even bigint is too small to store 
+    -- 18-decimal formatted integers
+    answer BYTEA,
 
     PRIMARY KEY(address, chain_id),
     CONSTRAINT address_length CHECK (LENGTH(address) = 20),
-    CONSTRAINT answer_tx_hash_length CHECK (LENGTH(answer_tx_hash) = 32)
+    CONSTRAINT answer_tx_hash_length CHECK (LENGTH(answer_tx_hash) = 32),
+    CONSTRAINT answer_length CHECK (LENGTH(answer_tx_hash) = 32)
 );

--- a/src/db.rs
+++ b/src/db.rs
@@ -10,7 +10,7 @@ use diesel::{
     sql_types::{Bytea, Jsonb},
     AsExpression, FromSqlRow,
 };
-use ethers::types::{Address, H256};
+use ethers::types::{Address, H256, U256};
 
 use crate::specification::Specification;
 
@@ -63,6 +63,33 @@ impl ToSql<Bytea, Pg> for DbTxHash {
     fn to_sql<'b>(&'b self, out: &mut serialize::Output<'b, '_, Pg>) -> serialize::Result {
         let value = self.0.as_bytes();
         <&[u8] as ToSql<Bytea, Pg>>::to_sql(&value, &mut out.reborrow())
+    }
+}
+
+#[derive(FromSqlRow, AsExpression, Debug, PartialEq)]
+#[diesel(sql_type = Bytea)]
+pub struct DbU256(pub U256);
+
+impl Deref for DbU256 {
+    type Target = U256;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl FromSql<Bytea, Pg> for DbU256 {
+    fn from_sql(bytes: PgValue) -> deserialize::Result<Self> {
+        let value = <Vec<u8> as FromSql<Bytea, Pg>>::from_sql(bytes)?;
+        Ok(DbU256(U256::from_big_endian(value.as_slice())))
+    }
+}
+
+impl ToSql<Bytea, Pg> for DbU256 {
+    fn to_sql<'b>(&'b self, out: &mut serialize::Output<'b, '_, Pg>) -> serialize::Result {
+        let mut value = [0u8; 32];
+        self.0.to_big_endian(&mut value);
+        <&[u8] as ToSql<Bytea, Pg>>::to_sql(&value.as_slice(), &mut out.reborrow())
     }
 }
 

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -7,6 +7,7 @@ diesel::table! {
         measurement_timestamp -> Timestamp,
         specification -> Jsonb,
         answer_tx_hash -> Nullable<Bytea>,
+        answer -> Nullable<Bytea>,
     }
 }
 

--- a/src/scanner/commons.rs
+++ b/src/scanner/commons.rs
@@ -161,7 +161,7 @@ pub async fn acknowledge_active_oracles(
 ) {
     let mut join_set = JoinSet::new();
     for data in oracles_data.into_iter() {
-        let oracle_address = format!("0x{}", data.address.to_string());
+        let oracle_address = format!("0x{:x}", data.address);
         join_set.spawn(
             acknowledge_active_oracle(
                 chain_id,
@@ -208,7 +208,7 @@ pub async fn acknowledge_active_oracle(
     {
         Ok(specification) => {
             if !specification::validate(&specification, defillama_http_client).await {
-                tracing::error!("specification validation failed for oracle at address {:x}, this won't be handled", oracle_data.address);
+                tracing::error!("specification validation failed for oracle at address 0x{:x}, this won't be handled", oracle_data.address);
                 return Ok(());
             }
 

--- a/src/scanner/present.rs
+++ b/src/scanner/present.rs
@@ -310,14 +310,14 @@ async fn answer_active_oracle(
                     }
                 };
                 tracing::info!(
-                    "paid {} to answer oracle {}",
+                    "paid {} to answer oracle 0x{:x}",
                     formatted,
                     active_oracle.address.deref()
                 );
             }
         } else {
             tracing::warn!(
-                "could not determine paid amount to answer oracle {}",
+                "could not determine paid amount to answer oracle 0x{:x}",
                 active_oracle.address.deref()
             );
         }

--- a/src/scanner/present.rs
+++ b/src/scanner/present.rs
@@ -319,7 +319,6 @@ async fn answer_active_oracle(
             tracing::warn!("could not determine paid amount to answer oracle");
         }
 
-        let active_oracle_address = active_oracle.address.0.clone();
         if let Err(error) = active_oracle.delete(&mut db_connection) {
             tracing::error!("could not delete oracle from database - {}", error);
             return Ok(());

--- a/tests/active_oracle.rs
+++ b/tests/active_oracle.rs
@@ -8,16 +8,19 @@ use defillama_answerer::{
     db::{
         models::{self, ActiveOracle},
         schema::active_oracles,
-        DbAddress, DbTxHash,
+        DbAddress, DbTxHash, DbU256,
     },
     specification::{handlers::tvl::TvlPayload, Specification},
 };
 use diesel::prelude::*;
-use ethers::{abi::Address, types::H256};
+use ethers::{
+    abi::Address,
+    types::{H256, U256},
+};
 
 #[test]
-fn test_to_from_sql() {
-    let context = TestContext::new("active_oracle_to_from_sql");
+fn test_to_from_sql_specification() {
+    let context = TestContext::new("active_oracle_to_from_sql_specification");
 
     let active_oracle = ActiveOracle {
         address: DbAddress(Address::random()),
@@ -27,6 +30,7 @@ fn test_to_from_sql() {
             protocol: "foo".to_owned(),
         }),
         answer_tx_hash: None,
+        answer: None,
     };
 
     let mut db_connection = context
@@ -51,6 +55,61 @@ fn test_to_from_sql() {
     assert_eq!(oracles.into_iter().nth(0).unwrap(), active_oracle);
 }
 
+// this also tests the answer update
+#[test]
+fn test_to_from_sql_answer() {
+    let context = TestContext::new("active_oracle_to_from_sql_answer");
+
+    let answer = U256::from(1);
+    let active_oracle = ActiveOracle {
+        address: DbAddress(Address::random()),
+        chain_id: 100,
+        measurement_timestamp: UNIX_EPOCH,
+        specification: Specification::Tvl(TvlPayload {
+            protocol: "foo".to_owned(),
+        }),
+        answer_tx_hash: None,
+        answer: Some(DbU256(answer)),
+    };
+
+    let mut db_connection = context
+        .db_connection_pool
+        .get()
+        .expect("could not get connection from pool");
+    let mut active_oracle = models::ActiveOracle::create(
+        &mut db_connection,
+        active_oracle.address.0,
+        active_oracle.chain_id as u64,
+        active_oracle.measurement_timestamp,
+        active_oracle.specification.clone(),
+    )
+    .expect("could not save active oracle to database");
+
+    // refetch the saved oracle and check that the answer is none
+    let oracles = models::ActiveOracle::get_all_answerable_for_chain_id(
+        &mut db_connection,
+        active_oracle.chain_id as u64,
+    )
+    .expect("could not get active oracles from database");
+    assert_eq!(oracles.len(), 1);
+    assert_eq!(oracles.into_iter().nth(0).unwrap(), active_oracle);
+
+    // update the answer in the database
+    active_oracle
+        .update_answer(&mut db_connection, answer)
+        .expect("could not update answer");
+    assert_eq!(active_oracle.answer, Some(DbU256(answer)));
+
+    // refetch the saved oracle and check that the answer is now correctly set
+    let oracles = models::ActiveOracle::get_all_answerable_for_chain_id(
+        &mut db_connection,
+        active_oracle.chain_id as u64,
+    )
+    .expect("could not get active oracles from database");
+    assert_eq!(oracles.len(), 1);
+    assert_eq!(oracles.into_iter().nth(0).unwrap(), active_oracle);
+}
+
 #[test]
 fn test_answer_tx_hash_update() {
     let context = TestContext::new("active_oracle_answer_tx_hash_update");
@@ -63,6 +122,7 @@ fn test_answer_tx_hash_update() {
             protocol: "foo".to_owned(),
         }),
         answer_tx_hash: None,
+        answer: None,
     };
 
     let mut db_connection = context
@@ -117,6 +177,7 @@ fn test_answer_tx_hash_deletion() {
             protocol: "foo".to_owned(),
         }),
         answer_tx_hash: Some(DbTxHash(H256::random())),
+        answer: None,
     };
     let mut db_connection = context
         .db_connection_pool
@@ -154,4 +215,56 @@ fn test_answer_tx_hash_deletion() {
     let updated_oracle_from_db = oracles.into_iter().nth(0).unwrap();
     assert_eq!(updated_oracle_from_db, oracle_from_db);
     assert!(updated_oracle_from_db.answer_tx_hash.is_none());
+}
+
+#[test]
+fn test_answer_deletion() {
+    let context = TestContext::new("active_oracle_answer_deletion");
+
+    // save initial active oracle to db
+    let active_oracle = ActiveOracle {
+        address: DbAddress(Address::random()),
+        chain_id: 100,
+        measurement_timestamp: UNIX_EPOCH,
+        specification: Specification::Tvl(TvlPayload {
+            protocol: "foo".to_owned(),
+        }),
+        answer_tx_hash: Some(DbTxHash(H256::random())),
+        answer: None,
+    };
+    let mut db_connection = context
+        .db_connection_pool
+        .get()
+        .expect("could not get connection from pool");
+    diesel::insert_into(active_oracles::table)
+        .values(&active_oracle)
+        .execute(&mut db_connection)
+        .expect("could not save active oracle to database");
+
+    // get it back and check that it's the same as the one we actually wanted to save
+    let oracles = models::ActiveOracle::get_all_answerable_for_chain_id(
+        &mut db_connection,
+        active_oracle.chain_id as u64,
+    )
+    .expect("could not get active oracles from database");
+    assert_eq!(oracles.len(), 1);
+    let mut oracle_from_db = oracles.into_iter().nth(0).unwrap();
+    assert_eq!(oracle_from_db, active_oracle);
+
+    // remove its answer
+    oracle_from_db
+        .delete_answer(&mut db_connection)
+        .expect("could not delete answer");
+    assert!(oracle_from_db.answer.is_none());
+
+    // get it once again from the database and verify that the tx hash is not there anymore
+    let oracles = models::ActiveOracle::get_all_answerable_for_chain_id(
+        &mut db_connection,
+        active_oracle.chain_id as u64,
+    )
+    .expect("could not get active oracles from database");
+    assert_eq!(oracles.len(), 1);
+    let updated_oracle_from_db = oracles.into_iter().nth(0).unwrap();
+    assert_eq!(updated_oracle_from_db, oracle_from_db);
+    assert!(updated_oracle_from_db.answer.is_none());
 }


### PR DESCRIPTION
This PR makes the answerer a bit more robust. For any given oracle, when the time comes to answer it, the final answer at that time is stored in the database, as opposed to what is done now, where the answer is fetched each time.

What this does is that no matter how long the answerer takes to answer the oracle for various reasons (such as network congestion or no funds being in its wallet), it will always submit the answer that was taken at the measurement timestamp, instead of a potential answer that was taken later due to previous failures.